### PR TITLE
Click option text instead of underlying object

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+ 0.06 / 2020-11-02
+  - Use the Down Arrow Button to get selectbox options
+    and option text to select
+
 0.05  2019-09-20
   - Add missing dependency declarations as reported by Kwalitee
 

--- a/dist.ini
+++ b/dist.ini
@@ -1,6 +1,6 @@
 name     = Weasel-Widgets-Dojo
 abstract = Weasel extension set testing Dojo-based web apps (tag matchers and widgets)
-version  = 0.05
+version  = 0.06
 author   = Erik Huelsmann <ehuels@gmail.com>
 copyright_holder = Erik Huelsmann
 main_module = lib/Weasel/FindExpanders/Dojo.pm

--- a/lib/Weasel/Widgets/Dojo/Option.pm
+++ b/lib/Weasel/Widgets/Dojo/Option.pm
@@ -43,7 +43,8 @@ sub click {
                            split /\s+/, $class);
         });
     }
-    $self->SUPER::click;
+    # Click the text, which masks $self under Firefox
+    $self->find("//*[\@id='" . $self->get_attribute('id') . "_text']")->SUPER::click;
     $self->session->wait_for(
       # Wait till popup closes
       sub {


### PR DESCRIPTION
Click on the text instead of the underlying object because Firefox makes it unreacheable.